### PR TITLE
Fix Git references at runtime.

### DIFF
--- a/dothtml.gemspec
+++ b/dothtml.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://github.com/kbrock/dothtml"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files         = `git ls-files -z`.split("\x0") if Dir.exist?(File.join(__dir__, ".git"))
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
Dothtml runs in the directory of the user's dot files, but needs
to run in a bundler context in order to avoid using the wrong gems.
To do so, it uses the Gemfile that is baked into the gem, however,
the Gemfile references the gemspec which in turn shells out to git.
A released gem does not have a .git directory, and this gives
warnings to STDERR.

The fix here is to avoid shelling out to git when the .git
directory doesn't exist.  This should not be a problem for
developers nor for deploying new versions.
