### PR TITLE
Fix issue where the path to the dothtml executable may not be correct.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.1.1] - 2016-03-04
+### Fixed
+- Fixed `dothtml watch` not finding the proper executable
+- Fixed `dothtml watch` complaining with `fatal: Not a git repository (or any of the parent directories): .git`
 
 ## [0.1.0] - 2016-02-09
 ### Added

--- a/lib/dothtml/cli.rb
+++ b/lib/dothtml/cli.rb
@@ -111,7 +111,7 @@ files are changed.
     def watch_command
       guardfile = File.join(TEMPLATES_DIR, "Guardfile")
       env = {
-        "DOTHTML_PATH"   => File.expand_path($0),
+        "DOTHTML_PATH"   => File.expand_path("../../exe/dothtml", __dir__),
         "BUNDLE_GEMFILE" => File.expand_path("../../Gemfile", __dir__)
       }
       exec(env, "bundle exec guard -G #{guardfile}")


### PR DESCRIPTION
@kbrock Please review.

This fixes an issue when running `dothtml guard` where it can't find the executable.  Unfortunately, in dev mode, you run it from the exe directly, but in production mode via the gem, it's on the PATH.  `$0` thus works differently and is why I didn't catch it.  This new way makes it work in both dev and prod modes.  Unfortunately, I had hacked this into my own gem locally and didn't realize it wasn't part of the initial PR.

This will require a version bump...I can make the CHANGELOG changes, just let me know.
